### PR TITLE
Fix typo on the "success" FR translation

### DIFF
--- a/utils/language.js
+++ b/utils/language.js
@@ -119,7 +119,7 @@ export default {
 		hint: 'Cliquez ou glissez le fichier ici.',
 		loading: 'Téléchargement…',
 		noSupported: 'Votre navigateur n\'est pas supporté. Utilisez IE10 + ou un autre navigateur s\'il vous plaît.',
-		success: 'Téléchargement réussit',
+		success: 'Téléchargement réussi',
 		fail: 'Téléchargement echoué',
 		preview: 'Aperçu',
 		btn: {


### PR DESCRIPTION
A mistake in French slipped into the translations.