### PR TITLE
修复上传文件file的type为undefined的问题

### DIFF
--- a/upload-1.vue
+++ b/upload-1.vue
@@ -456,6 +456,9 @@ export default {
 
         // 检测选择的文件是否合适
         checkFile(file) {
+            if (!file) {
+				return false;
+			}
             let that = this,
                 {
                     lang,

--- a/upload-2.vue
+++ b/upload-2.vue
@@ -455,6 +455,9 @@ export default {
 
 		// 检测选择的文件是否合适
 		checkFile(file) {
+			if (!file) {
+				return false;
+			}
 			let that = this,
 				{
 					lang,

--- a/upload-3.vue
+++ b/upload-3.vue
@@ -485,6 +485,9 @@ export default {
 
 		// 检测选择的文件是否合适
 		checkFile(file) {
+			if (!file) {
+				return false;
+			}
 			let that = this,
 				{
 					lang,


### PR DESCRIPTION
重现问题：当上传的图片小于裁剪的宽高时，再次点击上传，弹出选择文件框后，不选择图片，直接点击取消按钮，会报错
